### PR TITLE
Avoid RangeError from async

### DIFF
--- a/lib/MigratExecutor.js
+++ b/lib/MigratExecutor.js
@@ -64,7 +64,9 @@ module.exports = function MigratExecutor(project, plugins, runlist, options, wri
 					err = err || null;
 					async.series([
 						function executeAfterEachHook(callback) {
-							bridge.executeHook('afterEach', [err, item, callback]);
+							async.setImmediate(function () {
+								bridge.executeHook('afterEach', [err, item, callback]);
+							});
 						}
 					], function(_err) {
 						callback(err || _err || null);
@@ -77,7 +79,9 @@ module.exports = function MigratExecutor(project, plugins, runlist, options, wri
 		err = err || null;
 		async.series([
 			function executeAfterRunHook(callback) {
-				bridge.executeHook('afterRun', [err, runlist, callback]);
+				async.setImmediate(function () {
+					bridge.executeHook('afterRun', [err, runlist, callback]);
+				});
 			}
 		], function(_err) {
 			callback(err || _err || null);


### PR DESCRIPTION
When you have a lot of migrations (100+) you might have a recursion
problem with the async library with throw this error:

RangeError: Maximum call stack size exceeded

According to the documentation it is a common pitfall, and this commit
aims to fix it.

See: http://caolan.github.io/async/