### PR TITLE
Upgrade dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
   "author": "Brian Reavis <brian@thirdroute.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "async": "^0.9.0",
-    "lodash": "^2.4.1",
-    "chalk": "^0.5.1",
-    "yargs": "^1.3.2",
-    "minimatch": "^1.0.0",
-    "humanize-duration": "^2.0.1",
-    "figures": "^1.3.3"
+    "async": "^2.2.0",
+    "chalk": "^1.1.3",
+    "figures": "^2.0.0",
+    "humanize-duration": "^3.10.0",
+    "lodash": "^4.17.4",
+    "minimatch": "^3.0.3",
+    "yargs": "^7.0.2"
   },
   "devDependencies": {
-    "chai": "^1.9.2",
-    "mocha": "^2.0.0",
-    "fs-extra": "^0.12.0"
+    "chai": "^3.5.0",
+    "fs-extra": "^2.1.2",
+    "mocha": "^3.2.0"
   }
 }

--- a/test/MigratReader.js
+++ b/test/MigratReader.js
@@ -157,7 +157,7 @@ describe('MigratReader', function() {
 				assert.isNull(err);
 				assert.isArray(migrations);
 
-				var filenames = _.pluck(migrations, 'filename');
+				var filenames = _.map(migrations, 'filename');
 				assert.include(filenames, '1414006573623-first.js');
 				assert.include(filenames, '1414006573678-second.js');
 				assert.include(filenames, '1414006573679-third.all.js');

--- a/test/utils/runlistVerifier.js
+++ b/test/utils/runlistVerifier.js
@@ -3,17 +3,17 @@ var assert = require('chai').assert;
 var MigratRunList = require('../../lib/MigratRunList.js');
 
 module.exports = function(done, expected_results) {
-	var methods_expected =_.pluck(expected_results, 0);
-	var filenames_expected = _.pluck(expected_results, 1);
+	var methods_expected =_.map(expected_results, 0);
+	var filenames_expected = _.map(expected_results, 1);
 
 	return function(err, runlist) {
 		assert.isNull(err);
 		assert.instanceOf(runlist, MigratRunList);
 		assert.isArray(runlist.items);
 
-		var migrations = _.pluck(runlist.items, 'migration');
-		var methods = _.pluck(runlist.items, 'method');
-		var filenames = _.pluck(migrations, 'filename');
+		var migrations = _.map(runlist.items, 'migration');
+		var methods = _.map(runlist.items, 'method');
+		var filenames = _.map(migrations, 'filename');
 		var results = runlist.items.map(function(item) {
 			return [item.method, item.migration.filename];
 		});


### PR DESCRIPTION
Minimatch has a reported vulnerability, so took the opportunity to upgrade everything. Tested locally with a real migration suite and it worked.